### PR TITLE
Fixing namespace for cs urls

### DIFF
--- a/knockout-profile-viewer.js
+++ b/knockout-profile-viewer.js
@@ -29,8 +29,8 @@ ko.bindingHandlers.profileViewer = {
 			return;
 		}
 
-		if (window && window.civicsource && window.civicsource.payload) {
-			var profileUrl = window.civicsource.payload.urls.admin + "profiles/" + username;
+		if (window && window.civicsource && window.civicsource.urls) {
+			var profileUrl = window.civicsource.urls.admin + "profiles/" + username;
 
 			$.ajax(profileUrl, {
 				type: "GET",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "civicsource-knockout-profile-viewer",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Knockout component to view a CivicSource Administrator or Auctioneer Profile.",
   "main": "knockout-profile-viewer.js",
   "scripts": {


### PR DESCRIPTION
Fixes [CS-14616](https://jira.archoninfosys.com:8181/browse/CS-14616)

we are no longer storing urls on the payload but on the `civicsource` namespace